### PR TITLE
Usage code updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,20 +25,18 @@ Usage
 -----
 First, include jQuery and Mailcheck into the page.
 
-    <script type="text/javascript" src="jquery.min.js"></script>
-    <script type="text/javascript" src="jquery.mailcheck.min.js"></script>
+    <script src="jquery.min.js"></script>
+    <script src="jquery.mailcheck.min.js"></script>
 
 Have a text field.
 
-    <form id="form">
-      <input id="email" name="email" type="text" />
-    </form>
+    <input id="email" name="email" type="text" />
 
 Now, attach Mailcheck to the text field. Remember to declare an array of domains you want to check against.
 
-    <script type="text/javascript">
+    <script>
       var domains = ['hotmail.com', 'gmail.com', 'aol.com'];
-      $('form').on('blur', 'input#email', function() {
+      $('#email').on('blur', function() {
         $(this).mailcheck({
           domains: domains,   // optional
           suggested: function(element, suggestion) {


### PR DESCRIPTION
To keep the basic usage code as simple as possible, I figured I'd re-write the event binding.

Attaching an event handler to the parent and then pass in a child selector as the second argument to `.on()` is really only needed when the input is dynamically added to the document.

Also removed `type="text/javascript"` from `<script>` tags, all in the spirit of keeping thing tidy (and modern!)
