### PR TITLE
Return result 

### DIFF
--- a/src/mailcheck.js
+++ b/src/mailcheck.js
@@ -31,6 +31,8 @@ var Kicksend = {
       if (result) {
         if (opts.suggested) {
           opts.suggested(result);
+        } else {
+          return result;
         }
       } else {
         if (opts.empty) {


### PR DESCRIPTION
Added this so that I can run 'Kicksend.mailcheck.run' directly without
having to provide a 'suggested' callback. The run method currently doesn't return anything and relies on a callback being passed in. I found it useful to return the result directly if you just want to quickly test an email address against mailcheck.
