### PR TITLE
Add icloud.com domain

### DIFF
--- a/src/mailcheck.js
+++ b/src/mailcheck.js
@@ -19,7 +19,7 @@ var Kicksend = {
       "live.com", "comcast.net", "googlemail.com", "msn.com", "hotmail.co.uk", "yahoo.co.uk",
       "facebook.com", "verizon.net", "sbcglobal.net", "att.net", "gmx.com", "mail.com", "outlook.com", "icloud.com"],
 
-    defaultTopLevelDomains: ["co.jp", "co.uk", "com", "net", "org", "info", "edu", "gov", "mil"],
+    defaultTopLevelDomains: ["co.jp", "co.uk", "com", "net", "org", "info", "edu", "gov", "mil", "ca"],
 
     run: function(opts) {
       opts.domains = opts.domains || Kicksend.mailcheck.defaultDomains;


### PR DESCRIPTION
Adds icloud.com as a default, one of the most popular domains currently. Also includes .ca as a top level domain, which is of course very common among Canadian users.
