### PR TITLE
descriptive .min.js comment banner

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -4,7 +4,7 @@ module.exports = (grunt) ->
     pkg: grunt.file.readJSON('package.json'),
     uglify:
       options:
-        banner: '/*<%= pkg.version %>*/'
+        banner: '/*! <%= pkg.name %> v<%= pkg.version %> (c)2012 Received Inc, @licence MIT */'
       main:
         files:
           'src/mailcheck.min.js': 'src/mailcheck.js'


### PR DESCRIPTION
Filenames may be dropped when collated (Browserify, Polymer, X-Tag) or relayed via CDN.  So I added the filename & copyright info into `Gruntfile.coffee`.  `!` & `@licence` are flags to help minifiers prevent remvoal.
Test worked locally: `/*! mailcheck v1.0.4 (c)2012 Received Inc, @licence MIT */`
