### PR TITLE
Use diff thresholds for domain, top-level domain

### DIFF
--- a/spec/mailcheckSpec.js
+++ b/spec/mailcheckSpec.js
@@ -131,6 +131,11 @@ describe("mailcheck", function() {
          */
         expect(mailcheck.suggest('test@mail.randomsmallcompany.cmo', domains, topLevelDomains).domain).toBeFalsy();
       });
+
+      it("will not offer a suggestion that itself leads to another suggestion", function() {
+        var suggestion = mailcheck.suggest('test@yahooo.cmo', domains, topLevelDomains);
+        expect(suggestion.domain).toEqual('yahoo.com');
+      });
     });
 
     describe("mailcheck.splitEmail", function () {

--- a/src/mailcheck.js
+++ b/src/mailcheck.js
@@ -13,7 +13,8 @@
 
 var Kicksend = {
   mailcheck : {
-    threshold: 3,
+    domainThreshold: 4,
+    topLevelThreshold: 3,
 
     defaultDomains: ["yahoo.com", "google.com", "hotmail.com", "gmail.com", "me.com", "aol.com", "mac.com",
       "live.com", "comcast.net", "googlemail.com", "msn.com", "hotmail.co.uk", "yahoo.co.uk",
@@ -40,7 +41,7 @@ var Kicksend = {
 
       var emailParts = this.splitEmail(email);
 
-      var closestDomain = this.findClosestDomain(emailParts.domain, domains, distanceFunction);
+      var closestDomain = this.findClosestDomain(emailParts.domain, domains, distanceFunction, this.domainThreshold);
 
       if (closestDomain) {
         if (closestDomain != emailParts.domain) {
@@ -49,7 +50,7 @@ var Kicksend = {
         }
       } else {
         // The email address does not closely match one of the supplied domains
-        var closestTopLevelDomain = this.findClosestDomain(emailParts.topLevelDomain, topLevelDomains);
+        var closestTopLevelDomain = this.findClosestDomain(emailParts.topLevelDomain, topLevelDomains, distanceFunction, this.topLevelThreshold);
         if (emailParts.domain && closestTopLevelDomain && closestTopLevelDomain != emailParts.topLevelDomain) {
           // The email address may have a mispelled top-level domain; return a suggestion
           var domain = emailParts.domain;
@@ -64,7 +65,8 @@ var Kicksend = {
       return false;
     },
 
-    findClosestDomain: function(domain, domains, distanceFunction) {
+    findClosestDomain: function(domain, domains, distanceFunction, threshold) {
+      threshold = threshold || this.topLevelThreshold; 
       var dist;
       var minDist = 99;
       var closestDomain = null;
@@ -87,7 +89,7 @@ var Kicksend = {
         }
       }
 
-      if (minDist <= this.threshold && closestDomain !== null) {
+      if (minDist <= threshold && closestDomain !== null) {
         return closestDomain;
       } else {
         return false;


### PR DESCRIPTION
Use a higher threshold when checking for an exact match with an entire
domain. This is useful because otherwise we have a problem where
corrections can "chain" - test@yahooo.cmo leads to a suggestion of
test@yahooo.com, which leads to a suggestion of yahoo.com.

If the user was already corrected once, they shouldn't have to be
corrected again - especially since they're using the answer we just
gave them.
