### PR TITLE
Valid second-level + TLD combinations should not get recommendations

### DIFF
--- a/spec/mailcheckSpec.js
+++ b/spec/mailcheckSpec.js
@@ -1,7 +1,7 @@
 describe("mailcheck", function() {
   var domains = ['google.com', 'gmail.com', 'emaildomain.com', 'comcast.net', 'facebook.com', 'msn.com'];
-  var secondLevelDomains = ["yahoo", "hotmail", "mail", "live", "outlook", "gmx"];
-  var topLevelDomains = ['co.uk', 'com', 'org', 'info'];
+  var secondLevelDomains = ["yahoo", "hotmail", "mail", "live", "outlook", "gmx", "gmail"];
+  var topLevelDomains = ['co.uk', 'com', 'org', 'info', 'fr'];
 
   describe("Mailcheck", function(){
     var mailcheck;
@@ -137,6 +137,16 @@ describe("mailcheck", function() {
       it("will not offer a suggestion that itself leads to another suggestion", function() {
         var suggestion = mailcheck.suggest('test@yahooo.cmo', domains, secondLevelDomains, topLevelDomains);
         expect(suggestion.domain).toEqual('yahoo.com');
+      });
+
+      it("will not offer suggestions for valid 2ld-tld combinations", function() {
+        expect(
+            mailcheck.suggest('test@gmail.co.uk', domains, secondLevelDomains, topLevelDomains)
+        ).toBeFalsy();
+
+        expect(
+            mailcheck.suggest('test@gmail.fr', domains, secondLevelDomains, topLevelDomains)
+        ).toBeFalsy();
       });
     });
 

--- a/spec/mailcheckSpec.js
+++ b/spec/mailcheckSpec.js
@@ -1,6 +1,6 @@
 describe("mailcheck", function() {
-  var domains = ['google.com', 'gmail.com', 'emaildomain.com', 'comcast.net', 'facebook.com', 'msn.com'];
-  var secondLevelDomains = ["yahoo", "hotmail", "mail", "live", "outlook", "gmx", "gmail"];
+  var domains = ['google.com', 'gmail.com', 'emaildomain.com', 'comcast.net', 'facebook.com', 'msn.com', 'gmx.de'];
+  var secondLevelDomains = ["yahoo", "hotmail", "mail", "live", "outlook", "gmx"];
   var topLevelDomains = ['co.uk', 'com', 'org', 'info', 'fr'];
 
   describe("Mailcheck", function(){
@@ -121,7 +121,6 @@ describe("mailcheck", function() {
         expect(mailcheck.suggest('test@hotmail.co', domains, secondLevelDomains, topLevelDomains).domain).toEqual('hotmail.com');
         expect(mailcheck.suggest('test@yajoo.com', domains, secondLevelDomains, topLevelDomains).domain).toEqual('yahoo.com');
         expect(mailcheck.suggest('test@randomsmallcompany.cmo', domains, secondLevelDomains, topLevelDomains).domain).toEqual('randomsmallcompany.com');
-        expect(mailcheck.suggest('test@yahoo.co.uk', domains, secondLevelDomains, topLevelDomains)).toBeFalsy();
 
         expect(mailcheck.suggest('', domains)).toBeFalsy();
         expect(mailcheck.suggest('test@', domains)).toBeFalsy();
@@ -141,11 +140,13 @@ describe("mailcheck", function() {
 
       it("will not offer suggestions for valid 2ld-tld combinations", function() {
         expect(
-            mailcheck.suggest('test@gmail.co.uk', domains, secondLevelDomains, topLevelDomains)
+            mailcheck.suggest('test@yahoo.co.uk', domains, secondLevelDomains, topLevelDomains)
         ).toBeFalsy();
+      });
 
+      it("will not offer suggestions for valid 2ld-tld even if theres a close fully-specified domain", function() {
         expect(
-            mailcheck.suggest('test@gmail.fr', domains, secondLevelDomains, topLevelDomains)
+            mailcheck.suggest('test@gmx.fr', domains, secondLevelDomains, topLevelDomains)
         ).toBeFalsy();
       });
     });

--- a/src/mailcheck.js
+++ b/src/mailcheck.js
@@ -51,12 +51,19 @@ var Mailcheck = {
 
     var emailParts = this.splitEmail(email);
 
+    if (secondLevelDomains && topLevelDomains) {
+        // If the email is a valid 2nd-level + top-level, do not suggest anything.
+        if (secondLevelDomains.indexOf(emailParts.secondLevelDomain) !== -1 && topLevelDomains.indexOf(emailParts.topLevelDomain) !== -1) {
+            return false;
+        }
+    }
+
     var closestDomain = this.findClosestDomain(emailParts.domain, domains, distanceFunction, this.domainThreshold);
 
     if (closestDomain) {
       if (closestDomain == emailParts.domain) {
         // The email address exactly matches one of the supplied domains; do not return a suggestion.
-        return false
+        return false;
       } else {
         // The email address closely matches one of the supplied domains; return a suggestion
         return { address: emailParts.address, domain: closestDomain, full: emailParts.address + "@" + closestDomain };


### PR DESCRIPTION
cf #97, not sure if y'all actually want this but thought I'd put it out there in case you did.