### PR TITLE
Change the live demo URL to a working one

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Mailcheck will offer up suggestions for second and top level domains too. For ex
 
 ![diagram](https://raw.githubusercontent.com/mailcheck/mailcheck/master/doc/example.png)
 
-See it live in action [here](http://kicksend.com/join).
+See it live in action [here](https://www.kickstarter.com/signup).
 
 Installation
 ------------


### PR DESCRIPTION
The previous link seems dead now (the whole domain does, too), so I picked another one from the "Who uses Mailcheck" section that doesn't need further JS interaction to get to a form.

Would be best if this linked to a demo page instead, in my opinion, as Kickstarter (or anyone else) could potentially change signup paths.

But for now I guess that's better than a broken link.