### PR TITLE
"net" listed in defaultTopLevelDomains twice

### DIFF
--- a/src/mailcheck.js
+++ b/src/mailcheck.js
@@ -31,7 +31,7 @@ var Mailcheck = {
   defaultTopLevelDomains: ["com", "com.au", "com.tw", "ca", "co.nz", "co.uk", "de",
     "fr", "it", "ru", "net", "org", "edu", "gov", "jp", "nl", "kr", "se", "eu",
     "ie", "co.il", "us", "at", "be", "dk", "hk", "es", "gr", "ch", "no", "cz",
-    "in", "net", "net.au", "info", "biz", "mil", "co.jp", "sg", "hu", "uk"],
+    "in", "net.au", "info", "biz", "mil", "co.jp", "sg", "hu", "uk"],
 
   run: function(opts) {
     opts.domains = opts.domains || Mailcheck.defaultDomains;


### PR DESCRIPTION
"net" is already listed on line 32, but is repeated again on line 34 between "in" and "net.au".