### PR TITLE
Only add runtime files to npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+.DS_Store
+
+npm-debug.log
+spec
+doc
+examples


### PR DESCRIPTION
https://docs.npmjs.com/misc/developers#keeping-files-out-of-your-package

Fixes #169

It's generally good practice IMO to keep only the things consumers need to use your lib in npm. In this case, your specs folder references a vulnerable version of jquery, which is fine since it's not used at runtime, but it causes false positives for vulnerability scanners like retireJS.

Keeping your npm bundle slim is also good for helping fight node_modules cruft and slow installs.