### PR TITLE
Prevent @hey.com addresses from being suggested to be in error

### DIFF
--- a/src/mailcheck.js
+++ b/src/mailcheck.js
@@ -24,7 +24,7 @@ var Mailcheck = {
     'aim.com', 'rogers.com', 'verizon.net',
     'rocketmail.com', 'google.com', 'optonline.net',
     'sbcglobal.net', 'aol.com', 'me.com', 'btinternet.com',
-    'charter.net', 'shaw.ca'],
+    'charter.net', 'shaw.ca', 'hey.com'],
 
   defaultSecondLevelDomains: ["yahoo", "hotmail", "mail", "live", "outlook", "gmx"],
 


### PR DESCRIPTION
Right now mailcheck will suggest that someone entering "david@hey.com" really meant "david@sky.com".